### PR TITLE
Adds default value to `hidden` property for posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -101,6 +101,17 @@ show-author: true
 # do you want some animations?
 animation: true
 
+# add default values to specific pages or layouts
+defaults:
+  -
+    scope:
+      path: "" # an empty string here means all files in the project
+      layout: "post"
+    values:
+      # setting all post to not hidden by default, 
+      # can be overridden in the front matter for a specific post
+      hidden: false 
+      
 plugins:
   - jekyll-seo-tag
   - jekyll-gist


### PR DESCRIPTION
All pages with layout `post` are given a property `hidden` with default value of `false`. The value can be overwritten in the front matter of a specific post that you might want to set to hidden. Why? After PR https://github.com/sergiokopplin/indigo/pull/278 no navigation links were shown unless posts had explicitly been specified as not hidden (`hidden: false`). This PR is meant to fix this issue.